### PR TITLE
Custom allocator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,23 +94,32 @@ as `each`:
 		// do something with ent
 	});
 
-There is no direct equivalent to `all` for a range based for loop. You may, however, use `getEntities()` instead.
+You may also use `all` in a range based for loop in a similar fashion to `each`.
 
 ### Create the world
 
 Next, inside a `main()` function somewhere, you can add the following code to create the world, setup the system, and
 create an entity:
 
-    World world;
-    world.registerSystem(new GravitySystem(-9.8f));
+    World* world = World::createWorld();
+    world->registerSystem(new GravitySystem(-9.8f));
     
-    Entity* ent = world.create();
+    Entity* ent = world->create();
     ent->assign<Position>(0.f, 0.f); // assign() takes arguments and passes them to the constructor
     ent->assign<Rotation>(35.f);
 
 Now you can call the tick function on the world in order to tick all systems that have been registered with the world:
 
-    world.tick(deltaTime);
+    world->tick(deltaTime);
+	
+#### Custom Allocators
+
+You may use any standards-compliant custom allocator. The world handles all allocations for entities and components, and you may
+pass it a custom allocator like so:
+
+    World* world = World::createWorld<MyCustomAllocatorType<Entity>>(myCustomAllocator);
+
+The default implementation uses `std::allocator<Entity>`. Note that the world will rebind allocators for different types.
 
 ### Working with components
 
@@ -162,11 +171,11 @@ type of object, and you can subscribe to specific types of events by subclassing
     // ...
     
     MyEventSubscriber* mySubscriber = new MyEventSubscriber();
-    world.subscribe<MyEvent>(mySubscriber);
+    world->subscribe<MyEvent>(mySubscriber);
     
 Then, to emit an event:
 
-    world.emit<MyEvent>({ 123, 45.67f }); // you can use initializer syntax if you want, this sets foo = 123 and bar = 45.67f
+    world->emit<MyEvent>({ 123, 45.67f }); // you can use initializer syntax if you want, this sets foo = 123 and bar = 45.67f
 
 Make sure you call `unsubscribe` or `unsubscribeAll` on your subscriber before deleting it, or else emitting the event
 may cause a crash or other undesired behavior.

--- a/README.md
+++ b/README.md
@@ -112,16 +112,21 @@ Now you can call the tick function on the world in order to tick all systems tha
 
     world->tick(deltaTime);
 	
-Once you are done with the world, make sure to destroy it!
+Once you are done with the world, make sure to destroy it (this will also deallocate the world).
 
     world->destroy();
 	
 #### Custom Allocators
 
-You may use any standards-compliant custom allocator. The world handles all allocations for entities and components, and you may
-pass it a custom allocator like so:
+You may use any standards-compliant custom allocator. The world handles all allocations and deallocations for entities and components.
 
-    World* world = World::createWorld<MyCustomAllocatorType<Entity>>(myCustomAllocator);
+In order to use a custom allocator, define `ECS_ALLOCATOR_TYPE` before including `ECS.h`:
+
+    #define ECS_ALLOCATOR_TYPE MyAllocator<Entity>
+	#include "ECS.h"
+
+Allocators must have a default constructor. When creating the world with `World::createWorld`, you may pass in your custom
+allocator if you need to initialize it first. Additionally, custom allocators must be rebindable via `std::allocator_traits`.
 
 The default implementation uses `std::allocator<Entity>`. Note that the world will rebind allocators for different types.
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Now you can call the tick function on the world in order to tick all systems tha
 
     world->tick(deltaTime);
 	
+Once you are done with the world, make sure to destroy it!
+
+    world->destroy();
+	
 #### Custom Allocators
 
 You may use any standards-compliant custom allocator. The world handles all allocations for entities and components, and you may

--- a/sample.cpp
+++ b/sample.cpp
@@ -99,7 +99,7 @@ public:
 		// Let's delete an entity while iterating because why not?
 		world->all([&](auto* ent) {
 			if (ent->getEntityId() + 1 == event.num)
-				world->destroy(world->getEntityById(event.num));
+				world->destroy(world->getById(event.num));
 
 			if (ent->getEntityId() == event.num)
 				std::cout << "Woah, we shouldn't get here!" << std::endl;
@@ -112,17 +112,17 @@ int main(int argc, char** argv)
 	std::cout << "EntityComponentSystem Test" << std::endl
 		<< "==========================" << std::endl;
 
-	World world;
+	World* world = World::createWorld();
 
-	world.registerSystem(new TestSystem());
+	world->registerSystem(new TestSystem());
 
-	Entity* ent = world.create();
+	Entity* ent = world->create();
 	auto pos = ent->assign<Position>(0.f, 0.f);
 	auto rot = ent->assign<Rotation>(0.f);
 
 	std::cout << "Initial values: position(" << pos->x << ", " << pos->y << "), rotation(" << rot->angle << ")" << std::endl;
 
-	world.tick(10.f);
+	world->tick(10.f);
 
 	std::cout << "After tick(10): position(" << pos->x << ", " << pos->y << "), rotation(" << rot->angle << ")" << std::endl;
 
@@ -130,14 +130,14 @@ int main(int argc, char** argv)
 
 	for (int i = 0; i < 10; ++i)
 	{
-		ent = world.create();
+		ent = world->create();
 		ent->assign<SomeComponent>();
 	}
 
 	int count = 0;
 	std::cout << "Counting entities with SomeComponent..." << std::endl;
 	// range based for loop
-	for (auto ent : world.each<SomeComponent>())
+	for (auto ent : world->each<SomeComponent>())
 	{
 		++count;
 		std::cout << "Found entity #" << ent->getEntityId() << std::endl;
@@ -145,11 +145,11 @@ int main(int argc, char** argv)
 	std::cout << count << " entities have SomeComponent!" << std::endl;
 
 	// Emitting events
-	world.emit<SomeEvent>({ 4 });
+	world->emit<SomeEvent>({ 4 });
 
-	std::cout << "We have " << world.getEntities().size() << " entities right now." << std::endl;
-	world.cleanup();
-	std::cout << "After a cleanup, we have " << world.getEntities().size() << " entities." << std::endl;
+	std::cout << "We have " << world->getCount() << " entities right now." << std::endl;
+	world->cleanup();
+	std::cout << "After a cleanup, we have " << world->getCount() << " entities." << std::endl;
 
 	std::cout << "Press any key to exit..." << std::endl;
 	std::getchar();

--- a/sample.cpp
+++ b/sample.cpp
@@ -151,6 +151,10 @@ int main(int argc, char** argv)
 	world->cleanup();
 	std::cout << "After a cleanup, we have " << world->getCount() << " entities." << std::endl;
 
+	std::cout << "Destroying the world..." << std::endl;
+
+	world->destroyWorld();
+
 	std::cout << "Press any key to exit..." << std::endl;
 	std::getchar();
 


### PR DESCRIPTION
Custom allocators allow you to optionally control how memory is allocated and deallocated via the use of `std::allocator_traits` compliant allocators.