### PR TITLE
Allow systems to access entities and components during unconfigure

### DIFF
--- a/ECS.h
+++ b/ECS.h
@@ -940,6 +940,11 @@ namespace ECS
 
 	inline World::~World()
 	{
+		for (auto* system : systems)
+		{
+			system->unconfigure(this);
+		}
+
 		for (auto* ent : entities)
 		{
 			if (!ent->isPendingDestroy())
@@ -954,7 +959,6 @@ namespace ECS
 
 		for (auto* system : systems)
 		{
-			system->unconfigure(this);
 			std::allocator_traits<SystemAllocator>::destroy(systemAlloc, system);
 			std::allocator_traits<SystemAllocator>::deallocate(systemAlloc, system, 1);
 		}


### PR DESCRIPTION
If a system creates an entity in configure(), the system cannot then access that entity from unconfigure(). If the system stores a reference to the entity or one of its components in configure(), accessing that reference from unconfigure() will cause a crash.

By unconfigure()ing systems before entities are destroyed, systems can perform last minute data operations without the risk of crashing.